### PR TITLE
fix: Fixed selection - cvtColor issue

### DIFF
--- a/uvvid/cli.py
+++ b/uvvid/cli.py
@@ -1,4 +1,5 @@
 import click
+
 import cv2 as cv
 
 from .core import UVVID
@@ -30,13 +31,22 @@ def view(ctx, cursor, video):
         if ret is False:
             break
 
-        coord = uvvid.find_cursor(frame, template_frame, debug=debug)
+        coord = uvvid.find_cursor(frame, template_frame)
 
         if prev_frame is not None:
-            uvvid.is_cursor_drawing(frame,
-                                    prev_frame,
-                                    coord,
-                                    debug=debug)
+            drawing, color = uvvid.is_cursor_drawing(frame, prev_frame, coord)
+            if debug:
+                top_left = (coord[0] - template_frame.shape[0]//2,
+                            coord[1] - template_frame.shape[1]//2)
+                bottom_right = (coord[0] + template_frame.shape[0]//2,
+                                coord[1] + template_frame.shape[1]//2)
+                cv.rectangle(frame, top_left, bottom_right, (255, 255, 255), 1)
+                ds = "Drawing" if drawing else "Idle"
+                cv.rectangle(frame, (frame.shape[1] - 60, 20),
+                                    (frame.shape[1] - 40, 40), color, -1)
+                cv.putText(frame, ds, (frame.shape[1] - 150, 40),
+                           cv.FONT_HERSHEY_TRIPLEX, 0.6, (255, 255, 255), 1)
+
         cv.imshow('frame', frame)
         prev_frame = frame
         if cv.waitKey(1) & 0xFF == ord('q'):


### PR DESCRIPTION
- Fixed problem where `selection` variable holding area around cursor
  had shape (X, 0, X) which caused `cvtColor()` to return `None` object
  This bug was caused by clipping the corners  of selection with wrong axis.
  X was clipped by height and Y by width.
- Removed debug option from core code. Moved the code to uvvid command
  view option. Reason for this is because we were modifying original frame with debug info
  which id dirty and original frame should stay the same.
